### PR TITLE
Marketplace commission

### DIFF
--- a/casper-private-auction-core/Cargo.toml
+++ b/casper-private-auction-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-private-auction-core"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Alexander Limonov <alimonov@casperlabs.io>"]
 edition = "2018"
 

--- a/casper-private-auction-core/Cargo.toml
+++ b/casper-private-auction-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-private-auction-core"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Alexander Limonov <alimonov@casperlabs.io>"]
 edition = "2018"
 

--- a/casper-private-auction-core/Cargo.toml
+++ b/casper-private-auction-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-private-auction-core"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Alexander Limonov <alimonov@casperlabs.io>"]
 edition = "2018"
 

--- a/casper-private-auction-core/src/auction.rs
+++ b/casper-private-auction-core/src/auction.rs
@@ -201,6 +201,8 @@ impl crate::AuctionLogic for Auction {
                 AuctionData::set_winner(Some(bidder), Some(bid));
             }
         }
+
+        AuctionData::increase_auction_times();
         emit(&AuctionEvent::Bid { bidder, bid })
     }
 

--- a/casper-private-auction-core/src/auction.rs
+++ b/casper-private-auction-core/src/auction.rs
@@ -30,6 +30,15 @@ impl Auction {
         }
         // Get the existing bid, if any
         let mut bids = AuctionData::get_bids();
+        if bids.get(&bidder).is_none() {
+            if let Some(bidder_cap) = AuctionData::get_bidder_count_cap() {
+                if bidder_cap <= bids.len() {
+                    if let Some(lowest_bidder) = bids.get_spot(bid) {
+                        bids.remove_by_key(&lowest_bidder);
+                    }
+                }
+            }
+        }
         let auction_purse = AuctionData::get_auction_purse();
         let bid_amount = if let Some(current_bid) = bids.get(&bidder) {
             if bid <= current_bid {
@@ -155,7 +164,7 @@ impl crate::AuctionLogic for Auction {
         if !AuctionData::is_kyc_proved() {
             runtime::revert(AuctionError::KYCError);
         }
-        if get_call_stack().len() != 2{
+        if get_call_stack().len() != 2 {
             runtime::revert(AuctionError::DisallowedMiddleware);
         }
         // We do not check times here because we do that in Auction::add_bid

--- a/casper-private-auction-core/src/auction.rs
+++ b/casper-private-auction-core/src/auction.rs
@@ -1,6 +1,6 @@
 use casper_contract::{
     contract_api::{
-        runtime::{self},
+        runtime::{self, get_call_stack},
         system,
     },
     unwrap_or_revert::UnwrapOrRevert,
@@ -154,6 +154,9 @@ impl crate::AuctionLogic for Auction {
         }
         if !AuctionData::is_kyc_proved() {
             runtime::revert(AuctionError::KYCError);
+        }
+        if get_call_stack().len() != 2{
+            runtime::revert(AuctionError::DisallowedMiddleware);
         }
         // We do not check times here because we do that in Auction::add_bid
         // Figure out who is trying to bid and what their bid is

--- a/casper-private-auction-core/src/auction.rs
+++ b/casper-private-auction-core/src/auction.rs
@@ -201,11 +201,16 @@ impl crate::AuctionLogic for Auction {
         } else {
             Self::add_bid(bidder, bidder_purse, bid);
             if let (Some(_), Some(current_price)) = (winner, price) {
-                if bid > current_price {
+                let min_step = AuctionData::get_minimum_bid_step().unwrap_or_default();
+                if bid > current_price && bid - current_price >= min_step {
                     AuctionData::set_winner(Some(bidder), Some(bid));
+                } else {
+                    runtime::revert(AuctionError::BidTooLow)
                 }
             } else if let (None, None) = (winner, price) {
                 AuctionData::set_winner(Some(bidder), Some(bid));
+            } else {
+                runtime::revert(AuctionError::BadState)
             }
         }
 

--- a/casper-private-auction-core/src/bids.rs
+++ b/casper-private-auction-core/src/bids.rs
@@ -232,14 +232,14 @@ impl Bids {
     }
 
     /// Returns the account hash of the lowest bidder if the new bid is higher
-    pub fn get_spot(&self, new_item: U512) -> Option<AccountHash> {
+    pub fn get_spot(&self, new_item: U512) -> Option<(AccountHash, U512)> {
         let mut bidders = Vec::from_iter(self.to_map());
         bidders.sort_by(|&(_, a), &(_, b)| b.cmp(&a));
         let (lowest_bidder, lowest_bid) = bidders
             .pop()
             .unwrap_or_revert_with(AuctionError::UnreachableDeadEnd);
         if lowest_bid < new_item {
-            Some(lowest_bidder)
+            Some((lowest_bidder, lowest_bid))
         } else {
             None
         }

--- a/casper-private-auction-core/src/data.rs
+++ b/casper-private-auction-core/src/data.rs
@@ -36,7 +36,6 @@ pub const RESERVE: &str = "reserve_price";
 pub const START_PRICE: &str = "starting_price";
 pub const PRICE: &str = "winning_bid";
 pub const WINNER: &str = "current_winner";
-pub const BIDS: &str = "bids";
 pub const FINALIZED: &str = "finalized";
 pub const BID: &str = "bid";
 pub const BID_PURSE: &str = "bid_purse";
@@ -326,7 +325,6 @@ pub fn create_auction_named_keys() -> NamedKeys {
     let (start_time, cancellation_time, end_time): (u64, u64, u64) = auction_times_match();
     let winning_bid: Option<U512> = None;
     let current_winner: Option<Key> = None;
-    let bids: BTreeMap<AccountHash, U512> = BTreeMap::new();
     let finalized = false;
     let bidder_count_cap = runtime::get_named_arg::<Option<u64>>(BIDDER_NUMBER_CAP);
     // Get commissions from nft
@@ -362,7 +360,6 @@ pub fn create_auction_named_keys() -> NamedKeys {
         (RESERVE, reserve_price),
         (PRICE, winning_bid),
         (WINNER, current_winner),
-        (BIDS, bids),
         (FINALIZED, finalized),
         (EVENTS_COUNT, 0_u32),
         (COMMISSIONS, commissions),

--- a/casper-private-auction-core/src/data.rs
+++ b/casper-private-auction-core/src/data.rs
@@ -50,6 +50,7 @@ pub const COMMISSIONS: &str = "commissions";
 pub const KYC_HASH: &str = "kyc_package_hash";
 pub const BIDDER_NUMBER_CAP: &str = "bidder_count_cap";
 pub const AUCTION_TIMER_EXTENSION: &str = "auction_timer_extension";
+pub const MINIMUM_BID_STEP: &str = "minimum_bid_step";
 
 macro_rules! named_keys {
     ( $( ($name:expr, $value:expr) ),* ) => {
@@ -209,6 +210,10 @@ impl AuctionData {
         read_named_key_value(BIDDER_NUMBER_CAP)
     }
 
+    pub fn get_minimum_bid_step() -> Option<U512> {
+        read_named_key_value(MINIMUM_BID_STEP)
+    }
+
     pub fn get_commission_shares() -> BTreeMap<AccountHash, u16> {
         let commissions = Self::get_commissions();
         let mut converted_commissions: BTreeMap<AccountHash, u16> = BTreeMap::new();
@@ -345,6 +350,7 @@ pub fn create_auction_named_keys() -> NamedKeys {
     };
 
     let auction_timer_extension = runtime::get_named_arg::<Option<u64>>(AUCTION_TIMER_EXTENSION);
+    let minimum_bid_step = runtime::get_named_arg::<Option<U512>>(MINIMUM_BID_STEP);
 
     let mut named_keys = named_keys!(
         (OWNER, token_owner),
@@ -364,7 +370,8 @@ pub fn create_auction_named_keys() -> NamedKeys {
         (EVENTS_COUNT, 0_u32),
         (COMMISSIONS, commissions),
         (BIDDER_NUMBER_CAP, bidder_count_cap),
-        (AUCTION_TIMER_EXTENSION, auction_timer_extension)
+        (AUCTION_TIMER_EXTENSION, auction_timer_extension),
+        (MINIMUM_BID_STEP, minimum_bid_step)
     );
     add_empty_dict(&mut named_keys, EVENTS);
     named_keys

--- a/casper-private-auction-core/src/data.rs
+++ b/casper-private-auction-core/src/data.rs
@@ -50,6 +50,8 @@ pub const EVENTS_COUNT: &str = "auction_events_count";
 pub const COMMISSIONS: &str = "commissions";
 pub const KYC_HASH: &str = "kyc_package_hash";
 pub const BIDDER_NUMBER_CAP: &str = "bidder_count_cap";
+pub const AUCTION_TIMER_EXTENSION: &str = "auction_timer_extension";
+
 macro_rules! named_keys {
     ( $( ($name:expr, $value:expr) ),* ) => {
         {
@@ -262,7 +264,15 @@ impl AuctionData {
             },
         )
     }
+
+    pub fn increase_auction_times(){
+        if let Some(increment) = read_named_key_value::<Option<u64>>(AUCTION_TIMER_EXTENSION) {
+            write_named_key_value(END,AuctionData::get_end()+increment);
+            write_named_key_value(CANCEL,AuctionData::get_cancel_time()+increment);
+        }
+    }
 }
+
 
 // TODO: Rewrite to avoid the match guard
 fn auction_times_match() -> (u64, u64, u64) {
@@ -337,6 +347,8 @@ pub fn create_auction_named_keys() -> NamedKeys {
         None => BTreeMap::new(),
     };
 
+    let auction_timer_extension = runtime::get_named_arg::<Option<u64>>(AUCTION_TIMER_EXTENSION);
+
     let mut named_keys = named_keys!(
         (OWNER, token_owner),
         (BENEFICIARY_ACCOUNT, beneficiary_account),
@@ -355,7 +367,8 @@ pub fn create_auction_named_keys() -> NamedKeys {
         (FINALIZED, finalized),
         (EVENTS_COUNT, 0_u32),
         (COMMISSIONS, commissions),
-        (BIDDER_NUMBER_CAP, bidder_count_cap)
+        (BIDDER_NUMBER_CAP, bidder_count_cap),
+        (AUCTION_TIMER_EXTENSION, auction_timer_extension)
     );
     add_empty_dict(&mut named_keys, EVENTS);
     named_keys

--- a/casper-private-auction-core/src/data.rs
+++ b/casper-private-auction-core/src/data.rs
@@ -265,14 +265,13 @@ impl AuctionData {
         )
     }
 
-    pub fn increase_auction_times(){
+    pub fn increase_auction_times() {
         if let Some(increment) = read_named_key_value::<Option<u64>>(AUCTION_TIMER_EXTENSION) {
-            write_named_key_value(END,AuctionData::get_end()+increment);
-            write_named_key_value(CANCEL,AuctionData::get_cancel_time()+increment);
+            write_named_key_value(END, AuctionData::get_end() + increment);
+            write_named_key_value(CANCEL, AuctionData::get_cancel_time() + increment);
         }
     }
 }
-
 
 // TODO: Rewrite to avoid the match guard
 fn auction_times_match() -> (u64, u64, u64) {

--- a/casper-private-auction-core/src/data.rs
+++ b/casper-private-auction-core/src/data.rs
@@ -204,7 +204,7 @@ impl AuctionData {
         read_named_key_value(COMMISSIONS)
     }
 
-    pub fn get_bidder_count_cap() -> u8 {
+    pub fn get_bidder_count_cap() -> Option<u64> {
         read_named_key_value(BIDDER_NUMBER_CAP)
     }
 
@@ -319,7 +319,7 @@ pub fn create_auction_named_keys() -> NamedKeys {
     let current_winner: Option<Key> = None;
     let bids: BTreeMap<AccountHash, U512> = BTreeMap::new();
     let finalized = false;
-    let bidder_count_cap = runtime::get_named_arg::<u8>(BIDDER_NUMBER_CAP);
+    let bidder_count_cap = runtime::get_named_arg::<Option<u64>>(BIDDER_NUMBER_CAP);
     // Get commissions from nft
 
     let commissions_ret: Option<BTreeMap<String, String>> = runtime::call_versioned_contract(

--- a/casper-private-auction-core/src/data.rs
+++ b/casper-private-auction-core/src/data.rs
@@ -51,6 +51,8 @@ pub const KYC_HASH: &str = "kyc_package_hash";
 pub const BIDDER_NUMBER_CAP: &str = "bidder_count_cap";
 pub const AUCTION_TIMER_EXTENSION: &str = "auction_timer_extension";
 pub const MINIMUM_BID_STEP: &str = "minimum_bid_step";
+pub const MARKETPLACE_COMMISSION: &str = "marketplace_commission";
+pub const MARKETPLACE_ACCOUNT: &str = "marketplace_account";
 
 macro_rules! named_keys {
     ( $( ($name:expr, $value:expr) ),* ) => {
@@ -214,6 +216,13 @@ impl AuctionData {
         read_named_key_value(MINIMUM_BID_STEP)
     }
 
+    pub fn get_marketplace_data() -> (AccountHash, u32) {
+        (
+            read_named_key_value(MARKETPLACE_ACCOUNT),
+            read_named_key_value(MARKETPLACE_COMMISSION),
+        )
+    }
+
     pub fn get_commission_shares() -> BTreeMap<AccountHash, u16> {
         let commissions = Self::get_commissions();
         let mut converted_commissions: BTreeMap<AccountHash, u16> = BTreeMap::new();
@@ -351,6 +360,8 @@ pub fn create_auction_named_keys() -> NamedKeys {
 
     let auction_timer_extension = runtime::get_named_arg::<Option<u64>>(AUCTION_TIMER_EXTENSION);
     let minimum_bid_step = runtime::get_named_arg::<Option<U512>>(MINIMUM_BID_STEP);
+    let marketplace_commission = runtime::get_named_arg::<u32>(MARKETPLACE_COMMISSION);
+    let marketplace_account = runtime::get_named_arg::<AccountHash>(MARKETPLACE_ACCOUNT);
 
     let mut named_keys = named_keys!(
         (OWNER, token_owner),
@@ -371,7 +382,9 @@ pub fn create_auction_named_keys() -> NamedKeys {
         (COMMISSIONS, commissions),
         (BIDDER_NUMBER_CAP, bidder_count_cap),
         (AUCTION_TIMER_EXTENSION, auction_timer_extension),
-        (MINIMUM_BID_STEP, minimum_bid_step)
+        (MINIMUM_BID_STEP, minimum_bid_step),
+        (MARKETPLACE_COMMISSION, marketplace_commission),
+        (MARKETPLACE_ACCOUNT, marketplace_account)
     );
     add_empty_dict(&mut named_keys, EVENTS);
     named_keys

--- a/casper-private-auction-core/src/error.rs
+++ b/casper-private-auction-core/src/error.rs
@@ -24,6 +24,7 @@ pub enum AuctionError {
     NewBidLower = 20,
     InvalidCallStackLength = 21,
     CannotCancelAuction = 22,
+    DisallowedMiddleware = 23,
 }
 
 impl From<AuctionError> for ApiError {

--- a/casper-private-auction-core/src/error.rs
+++ b/casper-private-auction-core/src/error.rs
@@ -25,6 +25,7 @@ pub enum AuctionError {
     InvalidCallStackLength = 21,
     CannotCancelAuction = 22,
     DisallowedMiddleware = 23,
+    UnreachableDeadEnd = 24,
 }
 
 impl From<AuctionError> for ApiError {

--- a/casper-private-auction-installer/Cargo.toml
+++ b/casper-private-auction-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-private-auction-installer"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Alexander Limonov <alimonov@casperlabs.io>"]
 edition = "2018"
 

--- a/casper-private-auction-installer/Cargo.toml
+++ b/casper-private-auction-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-private-auction-installer"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Alexander Limonov <alimonov@casperlabs.io>"]
 edition = "2018"
 

--- a/casper-private-auction-installer/Cargo.toml
+++ b/casper-private-auction-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-private-auction-installer"
-version = "0.3.1"
+version = "0.6.0"
 authors = ["Alexander Limonov <alimonov@casperlabs.io>"]
 edition = "2018"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.3.1"
+version = "0.6.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/src/auction.rs
+++ b/tests/src/auction.rs
@@ -431,4 +431,12 @@ impl AuctionContract {
             self.get_account_balance(&self.bob),
         )
     }
+
+    pub fn get_marketplace_balance(&self) -> U512 {
+        let account = self
+            .builder
+            .get_account(AccountHash::new([11_u8; 32]))
+            .expect("should get genesis account");
+        self.builder.get_purse_balance(account.main_purse())
+    }
 }

--- a/tests/src/auction_args.rs
+++ b/tests/src/auction_args.rs
@@ -28,6 +28,7 @@ pub struct AuctionArgsBuilder {
     end_time: u64,
     name: String,
     bidder_count_cap: Option<u64>,
+    auction_timer_extension: Option<u64>
 }
 
 impl AuctionArgsBuilder {
@@ -51,7 +52,8 @@ impl AuctionArgsBuilder {
             cancellation_time: 3000,
             end_time: 3500,
             name: "test".to_string(),
-            bidder_count_cap: Some(10),
+            bidder_count_cap: None,
+            auction_timer_extension: None
         }
     }
 
@@ -103,6 +105,10 @@ impl AuctionArgsBuilder {
         self.bidder_count_cap = bidder_count_cap;
     }
 
+    pub fn set_auction_timer_extension(&mut self, auction_timer_extension: Option<u64>) {
+        self.auction_timer_extension = auction_timer_extension;
+    }
+
     pub fn build(&self) -> RuntimeArgs {
         runtime_args! {
             "beneficiary_account"=>Key::Account(self.beneficiary_account),
@@ -116,7 +122,8 @@ impl AuctionArgsBuilder {
             "cancellation_time" => self.start_time+self.cancellation_time,
             "end_time" => self.start_time+self.end_time,
             "name" => self.name.clone(),
-            "bidder_count_cap" => self.bidder_count_cap
+            "bidder_count_cap" => self.bidder_count_cap,
+            "auction_timer_extension" => self.auction_timer_extension
         }
     }
 
@@ -145,7 +152,8 @@ impl Default for AuctionArgsBuilder {
             cancellation_time: 3000,
             end_time: 3500,
             name: "test".to_string(),
-            bidder_count_cap: Some(10),
+            bidder_count_cap: None,
+            auction_timer_extension: None
         }
     }
 }

--- a/tests/src/auction_args.rs
+++ b/tests/src/auction_args.rs
@@ -27,7 +27,7 @@ pub struct AuctionArgsBuilder {
     cancellation_time: u64,
     end_time: u64,
     name: String,
-    bidder_count_cap: u8,
+    bidder_count_cap: Option<u64>,
 }
 
 impl AuctionArgsBuilder {
@@ -51,7 +51,7 @@ impl AuctionArgsBuilder {
             cancellation_time: 3000,
             end_time: 3500,
             name: "test".to_string(),
-            bidder_count_cap: 10,
+            bidder_count_cap: Some(10),
         }
     }
 
@@ -99,7 +99,7 @@ impl AuctionArgsBuilder {
         self.end_time = end_time;
     }
 
-    pub fn set_bidder_count_cap(&mut self, bidder_count_cap: u8) {
+    pub fn set_bidder_count_cap(&mut self, bidder_count_cap: Option<u64>) {
         self.bidder_count_cap = bidder_count_cap;
     }
 
@@ -145,7 +145,7 @@ impl Default for AuctionArgsBuilder {
             cancellation_time: 3000,
             end_time: 3500,
             name: "test".to_string(),
-            bidder_count_cap: 10,
+            bidder_count_cap: Some(10),
         }
     }
 }

--- a/tests/src/auction_args.rs
+++ b/tests/src/auction_args.rs
@@ -28,7 +28,7 @@ pub struct AuctionArgsBuilder {
     end_time: u64,
     name: String,
     bidder_count_cap: Option<u64>,
-    auction_timer_extension: Option<u64>
+    auction_timer_extension: Option<u64>,
 }
 
 impl AuctionArgsBuilder {
@@ -53,7 +53,7 @@ impl AuctionArgsBuilder {
             end_time: 3500,
             name: "test".to_string(),
             bidder_count_cap: None,
-            auction_timer_extension: None
+            auction_timer_extension: None,
         }
     }
 
@@ -153,7 +153,7 @@ impl Default for AuctionArgsBuilder {
             end_time: 3500,
             name: "test".to_string(),
             bidder_count_cap: None,
-            auction_timer_extension: None
+            auction_timer_extension: None,
         }
     }
 }

--- a/tests/src/auction_args.rs
+++ b/tests/src/auction_args.rs
@@ -30,6 +30,8 @@ pub struct AuctionArgsBuilder {
     bidder_count_cap: Option<u64>,
     auction_timer_extension: Option<u64>,
     minimum_bid_step: Option<U512>,
+    marketplace_account: AccountHash,
+    marketplace_commission: u32,
 }
 
 impl AuctionArgsBuilder {
@@ -56,6 +58,8 @@ impl AuctionArgsBuilder {
             bidder_count_cap: None,
             auction_timer_extension: None,
             minimum_bid_step: None,
+            marketplace_account: AccountHash::new([11_u8; 32]),
+            marketplace_commission: 75,
         }
     }
 
@@ -131,6 +135,8 @@ impl AuctionArgsBuilder {
             "bidder_count_cap" => self.bidder_count_cap,
             "auction_timer_extension" => self.auction_timer_extension,
             "minimum_bid_step" => self.minimum_bid_step,
+            "marketplace_account" => self.marketplace_account,
+            "marketplace_commission" => self.marketplace_commission,
         }
     }
 
@@ -162,6 +168,8 @@ impl Default for AuctionArgsBuilder {
             bidder_count_cap: None,
             auction_timer_extension: None,
             minimum_bid_step: None,
+            marketplace_account: AccountHash::new([11_u8; 32]),
+            marketplace_commission: 75,
         }
     }
 }

--- a/tests/src/auction_args.rs
+++ b/tests/src/auction_args.rs
@@ -29,6 +29,7 @@ pub struct AuctionArgsBuilder {
     name: String,
     bidder_count_cap: Option<u64>,
     auction_timer_extension: Option<u64>,
+    minimum_bid_step: Option<U512>,
 }
 
 impl AuctionArgsBuilder {
@@ -54,6 +55,7 @@ impl AuctionArgsBuilder {
             name: "test".to_string(),
             bidder_count_cap: None,
             auction_timer_extension: None,
+            minimum_bid_step: None,
         }
     }
 
@@ -109,6 +111,10 @@ impl AuctionArgsBuilder {
         self.auction_timer_extension = auction_timer_extension;
     }
 
+    pub fn set_minimum_bid_step(&mut self, minimum_bid_step: Option<U512>) {
+        self.minimum_bid_step = minimum_bid_step;
+    }
+
     pub fn build(&self) -> RuntimeArgs {
         runtime_args! {
             "beneficiary_account"=>Key::Account(self.beneficiary_account),
@@ -123,7 +129,8 @@ impl AuctionArgsBuilder {
             "end_time" => self.start_time+self.end_time,
             "name" => self.name.clone(),
             "bidder_count_cap" => self.bidder_count_cap,
-            "auction_timer_extension" => self.auction_timer_extension
+            "auction_timer_extension" => self.auction_timer_extension,
+            "minimum_bid_step" => self.minimum_bid_step,
         }
     }
 
@@ -154,6 +161,7 @@ impl Default for AuctionArgsBuilder {
             name: "test".to_string(),
             bidder_count_cap: None,
             auction_timer_extension: None,
+            minimum_bid_step: None,
         }
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -401,16 +401,13 @@ fn english_increase_time_test() {
     let mut auction_args = auction_args::AuctionArgsBuilder::default();
     auction_args.set_auction_timer_extension(Some(10000));
     let mut auction_contract = auction::AuctionContract::deploy_contracts(auction_args);
-    assert_eq!(auction_contract.get_end(), now+4000);
+    assert_eq!(auction_contract.get_end(), now + 4000);
 
     auction_contract.bid(&auction_contract.bob.clone(), U512::from(30000), now + 1000);
-    assert_eq!(auction_contract.get_end(), now+14000);
+    assert_eq!(auction_contract.get_end(), now + 14000);
     auction_contract.cancel_bid(&auction_contract.bob.clone(), now + 12999);
     auction_contract.finalize(&auction_contract.admin.clone(), now + 14000);
     assert!(auction_contract.is_finalized());
     assert_eq!(None, auction_contract.get_winner());
-    assert_eq!(
-        None,
-        auction_contract.get_winning_bid()
-    );
+    assert_eq!(None, auction_contract.get_winning_bid());
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -217,7 +217,9 @@ fn auction_unknown_format_test() {
         "name" => "test",
         "bidder_count_cap" => Some(10_u64),
         "auction_timer_extension" => None::<u64>,
-        "minimum_bid_step"=> None::<U512>
+        "minimum_bid_step"=> None::<U512>,
+        "marketplace_account" => AccountHash::new([11_u8; 32]),
+        "marketplace_commission" => 75
     };
 
     let (auction_hash, auction_package) =
@@ -268,7 +270,9 @@ fn auction_bad_times_test() {
         "name" => "test",
         "bidder_count_cap" => Some(10_u64),
         "auction_timer_extension" => None::<u64>,
-        "minimum_bid_step"=> None::<U512>
+        "minimum_bid_step"=> None::<U512>,
+        "marketplace_account" => AccountHash::new([11_u8; 32]),
+        "marketplace_commission" => 75
     };
 
     let (auction_hash, auction_package) =
@@ -335,7 +339,9 @@ fn auction_bid_no_kyc_token_test() {
         "name" => "test",
         "bidder_count_cap" => Some(10_u64),
         "auction_timer_extension" => None::<u64>,
-        "minimum_bid_step"=> None::<U512>
+        "minimum_bid_step"=> None::<U512>,
+        "marketplace_account" => AccountHash::new([11_u8; 32]),
+        "marketplace_commission" => 75
     };
 
     let (auction_hash, auction_package) =
@@ -439,4 +445,19 @@ fn english_auction_bid_step_test_failing() {
     let mut auction_contract = auction::AuctionContract::deploy_contracts(auction_args);
     auction_contract.bid(&auction_contract.bob.clone(), U512::from(30000), now + 1000);
     auction_contract.bid(&auction_contract.ali.clone(), U512::from(40000), now + 1001);
+}
+
+#[test]
+fn marketplace_commission_test() {
+    let now = auction_args::AuctionArgsBuilder::get_now_u64();
+    let mut auction_args = auction_args::AuctionArgsBuilder::default();
+    let mut auction_contract = auction::AuctionContract::deploy_contracts(auction_args);
+    auction_contract.bid(
+        &auction_contract.ali.clone(),
+        U512::from(100000),
+        now + 1000,
+    );
+    auction_contract.finalize(&auction_contract.admin.clone(), now + 4000);
+    assert!(auction_contract.is_finalized());
+    assert_eq!(auction_contract.get_marketplace_balance(), U512::from(7500));
 }


### PR DESCRIPTION
two new arguments on deploy:
"marketplace_account" an `AccountHash`
"marketplace_commission" a u32 representing thousandths
marketplace_account receives marketplace_commission number of thousandths of the winning bid, then the rest is shared among other commissions, and the beneficiary